### PR TITLE
:recycle: Simplify `run()` using `Server` and `NewMux()`

### DIFF
--- a/main.go
+++ b/main.go
@@ -5,14 +5,11 @@ import (
 	"fmt"
 	"log"
 	"net"
-	"net/http"
 	"os"
 	"os/signal"
 	"syscall"
-	"time"
 
 	"github.com/Rindrics/go_todo_app/config"
-	"golang.org/x/sync/errgroup"
 )
 
 func run(ctx context.Context) error {
@@ -28,30 +25,8 @@ func run(ctx context.Context) error {
 	}
 	url := fmt.Sprintf("http://%s", l.Addr().String())
 	log.Printf("start with: %v", url)
-	s := &http.Server{
-		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			time.Sleep(5 * time.Second)
-			fmt.Fprintf(w, "Hello, %s!", r.URL.Path[1:])
-		}),
-	}
-
-	eg, ctx := errgroup.WithContext(ctx)
-
-	eg.Go(func() error {
-		if err := s.Serve(l); err != nil &&
-			err != http.ErrServerClosed {
-			log.Printf("failed to close: %+v", err)
-			return err
-		}
-		return nil
-	})
-
-	<-ctx.Done()
-	if err := s.Shutdown(context.Background()); err != nil {
-		log.Printf("failed to shutdown: %+v", err)
-	}
-
-	return eg.Wait()
+	s := NewServer(l, NewMux())
+	return s.Run(ctx)
 }
 
 func main() {


### PR DESCRIPTION
close #16